### PR TITLE
Make code compatible with zig 0.8 (master)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -22,7 +22,7 @@ pub fn main() anyerror!void {
     const file_name = try args.next(allocator) orelse return error.MandatoryFilenameArgumentNotGiven;
     const file = try std.fs.cwd().openFile(file_name, .{ .read = true, .write = false });
 
-    const stream = &file.inStream();
+    const stream = &file.reader();
 
     var state = SvdParseState.Device;
     var dev = try svd.Device.init(allocator);
@@ -305,7 +305,7 @@ pub fn main() anyerror!void {
         }
     }
     if (state == .Finished) {
-        try std.io.getStdOut().outStream().print("{}\n", .{dev});
+        try std.io.getStdOut().writer().print("{}\n", .{dev});
     } else {
         return error.InvalidXML;
     }


### PR DESCRIPTION
- inStream -> reader
- outStream -> writer
- strings need an explicit {s} format
- is_signed -> signedness in builtin.TypeInfo.Int

The last one is the only change that is not compatible with Zig 0.7, so a
compile time check was added to maintain compatibility with both Zig versions